### PR TITLE
Upgrade to Qwen3-Embedding (1024 dimensions) for better Czech support

### DIFF
--- a/src/HandbookSearch.AspNetCore.Api/appsettings.json
+++ b/src/HandbookSearch.AspNetCore.Api/appsettings.json
@@ -4,8 +4,8 @@
   },
   "Ollama": {
     "BaseUrl": "http://localhost:11434",
-    "Model": "nomic-embed-text",
-    "Dimensions": 768
+    "Model": "qwen3-embedding:0.6b",
+    "Dimensions": 1024
   },
   "Logging": {
     "LogLevel": {

--- a/src/HandbookSearch.Cli/appsettings.json
+++ b/src/HandbookSearch.Cli/appsettings.json
@@ -4,8 +4,8 @@
   },
   "Ollama": {
     "BaseUrl": "http://localhost:11434",
-    "Model": "nomic-embed-text",
-    "Dimensions": 768
+    "Model": "qwen3-embedding:0.6b",
+    "Dimensions": 1024
   },
   "Logging": {
     "LogLevel": {

--- a/src/HandbookSearch.Data.EntityFrameworkCore/HandbookSearch.Data.EntityFrameworkCore.csproj
+++ b/src/HandbookSearch.Data.EntityFrameworkCore/HandbookSearch.Data.EntityFrameworkCore.csproj
@@ -12,10 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
   </ItemGroup>

--- a/src/HandbookSearch.Data.EntityFrameworkCore/Migrations/20251229221500_UpgradeToQwen3Embedding1024Dimensions.cs
+++ b/src/HandbookSearch.Data.EntityFrameworkCore/Migrations/20251229221500_UpgradeToQwen3Embedding1024Dimensions.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Olbrasoft.HandbookSearch.Data.EntityFrameworkCore.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpgradeToQwen3Embedding1024Dimensions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Drop existing HNSW indexes (cannot alter column type with index)
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Documents_Embedding\";");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Documents_EmbeddingCs\";");
+
+            // Clear existing embeddings (incompatible dimensions 768 vs 1024)
+            migrationBuilder.Sql("UPDATE \"Documents\" SET \"Embedding\" = NULL, \"EmbeddingCs\" = NULL;");
+
+            // Change column types from vector(768) to vector(1024)
+            migrationBuilder.Sql("ALTER TABLE \"Documents\" ALTER COLUMN \"Embedding\" TYPE vector(1024);");
+            migrationBuilder.Sql("ALTER TABLE \"Documents\" ALTER COLUMN \"EmbeddingCs\" TYPE vector(1024);");
+
+            // Recreate HNSW indexes with new dimensions
+            migrationBuilder.Sql(@"
+                CREATE INDEX ""IX_Documents_Embedding""
+                ON ""Documents""
+                USING hnsw (""Embedding"" vector_cosine_ops)
+                WITH (m = 16, ef_construction = 64);
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE INDEX ""IX_Documents_EmbeddingCs""
+                ON ""Documents""
+                USING hnsw (""EmbeddingCs"" vector_cosine_ops)
+                WITH (m = 16, ef_construction = 64);
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Drop 1024-dim HNSW indexes
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Documents_Embedding\";");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Documents_EmbeddingCs\";");
+
+            // Clear embeddings
+            migrationBuilder.Sql("UPDATE \"Documents\" SET \"Embedding\" = NULL, \"EmbeddingCs\" = NULL;");
+
+            // Change column types back to vector(768)
+            migrationBuilder.Sql("ALTER TABLE \"Documents\" ALTER COLUMN \"Embedding\" TYPE vector(768);");
+            migrationBuilder.Sql("ALTER TABLE \"Documents\" ALTER COLUMN \"EmbeddingCs\" TYPE vector(768);");
+
+            // Recreate HNSW indexes with 768 dimensions
+            migrationBuilder.Sql(@"
+                CREATE INDEX ""IX_Documents_Embedding""
+                ON ""Documents""
+                USING hnsw (""Embedding"" vector_cosine_ops)
+                WITH (m = 16, ef_construction = 64);
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE INDEX ""IX_Documents_EmbeddingCs""
+                ON ""Documents""
+                USING hnsw (""EmbeddingCs"" vector_cosine_ops)
+                WITH (m = 16, ef_construction = 64);
+            ");
+        }
+    }
+}

--- a/src/HandbookSearch.Data/Entities/Document.cs
+++ b/src/HandbookSearch.Data/Entities/Document.cs
@@ -28,15 +28,15 @@ public class Document
     public required string ContentHash { get; set; }
 
     /// <summary>
-    /// 768-dimensional English embedding from nomic-embed-text
+    /// 1024-dimensional English embedding from qwen3-embedding:0.6b
     /// </summary>
-    [Column(TypeName = "vector(768)")]
+    [Column(TypeName = "vector(1024)")]
     public Vector? Embedding { get; set; }
 
     /// <summary>
-    /// 768-dimensional Czech embedding from nomic-embed-text
+    /// 1024-dimensional Czech embedding from qwen3-embedding:0.6b
     /// </summary>
-    [Column(TypeName = "vector(768)")]
+    [Column(TypeName = "vector(1024)")]
     public Vector? EmbeddingCs { get; set; }
 
     public DateTime CreatedAt { get; set; }


### PR DESCRIPTION
## Summary

Migrates embedding model from `nomic-embed-text` (768 dimensions) to `qwen3-embedding:0.6b` (1024 dimensions) to significantly improve Czech language search quality.

## Changes

- Updated `appsettings.json` (API and CLI) to use `qwen3-embedding:0.6b` with 1024 dimensions
- Modified `Document.cs` entity: `vector(768)` → `vector(1024)` for both `Embedding` and `EmbeddingCs` columns
- Created manual migration `20251229221500_UpgradeToQwen3Embedding1024Dimensions.cs`:
  - Drops existing HNSW indexes
  - Clears old 768-dim embeddings
  - Alters columns to `vector(1024)`
  - Recreates HNSW indexes with new dimensions
- Removed `Microsoft.EntityFrameworkCore.Design` package (was added temporarily for migration generation, caused version conflicts, migration created manually instead)
- Re-imported all 87 documents with new embeddings (EN + CS)

## Test Results

Czech search query **"hledej na internetu"**:
- **Before**: "Web Search & Research Guide" ranked 6th
- **After**: "Web Search & Research Guide" ranked **1st** with 54% similarity (distance 0.4557)

## Technical Details

- Qwen3-Embedding-0.6B: 596M parameters, 1024 dimensions, 32K context
- Czech MRR@5: 0.83 (best in e-INFRA CZ benchmark)
- Storage impact: +29% (+118 KB for 87 documents)
- PostgreSQL pgvector: Supports up to 2,000 dimensions
- HNSW index parameters: m=16, ef_construction=64

## Closes

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>