### PR TITLE
Integrate Azure Translator fallback into Business layer

### DIFF
--- a/tests/HandbookSearch.Business.Tests/Services/AzureTranslationServiceTests.cs
+++ b/tests/HandbookSearch.Business.Tests/Services/AzureTranslationServiceTests.cs
@@ -65,7 +65,10 @@ public class AzureTranslationServiceTests
                 };
             });
 
-        var httpClient = new HttpClient(handlerMock.Object);
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("https://api.cognitive.microsofttranslator.com")
+        };
         var service = new AzureTranslationService(httpClient, options, mockLogger.Object);
 
         // Act
@@ -130,7 +133,10 @@ public class AzureTranslationServiceTests
                 };
             });
 
-        var httpClient = new HttpClient(handlerMock.Object);
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("https://api.cognitive.microsofttranslator.com")
+        };
         var service = new AzureTranslationService(httpClient, options, mockLogger.Object);
 
         // Act
@@ -195,7 +201,10 @@ public class AzureTranslationServiceTests
                 };
             });
 
-        var httpClient = new HttpClient(handlerMock.Object);
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("https://api.cognitive.microsofttranslator.com")
+        };
         var service = new AzureTranslationService(httpClient, options, mockLogger.Object);
 
         // Act


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Integrates Azure Translator fallback mechanism into Business layer (`AzureTranslationService`), enabling automatic failover from primary to fallback account on API errors.

Resolves #33

## Changes

### Configuration
- ✅ Added `FallbackApiKey` property to `AzureTranslatorOptions` (optional)
- ✅ Modified constructor to set HTTP headers per-request instead of in constructor

### Implementation
- ✅ Implemented `TranslateWithFallbackAsync` with complete fallback logic
- ✅ Implemented `SendTranslationRequestAsync` with dynamic API key support
- ✅ Added helper methods:
  - `IsFallbackEligible` - determines if error qualifies for fallback (401, 403, 429)
  - `TryParseErrorDetails` - parses Azure error responses
  - `GetNextQuotaResetDate` - calculates quota reset date
- ✅ Updated `TranslateToCzechAsync` to use fallback mechanism
- ✅ **Preserved existing rate limiting functionality** (critical requirement)

### Tests
- ✅ Added comprehensive unit tests (8 test scenarios):
  - Primary 429 → Fallback succeeds
  - Primary 403 → Fallback succeeds
  - Primary 401 → Fallback succeeds
  - Both accounts 429 → Throws with helpful message
  - Both accounts 403 → Throws with quota reset date
  - No fallback key → Throws immediately
  - Success with primary account
  - Success returns translated text

All tests passing: **17/17** ✅

## Technical Details

**Fallback Trigger Conditions:**
- `401 Unauthorized` - Invalid or expired API key
- `403 Forbidden` - Quota exceeded
- `429 Too Many Requests` - Rate limit exceeded

**Error Handling:**
- If fallback key is not configured → logs error and throws original exception
- If both accounts fail → logs critical error with both status codes and quota reset date

**Logging:**
- Information: Fallback activation, successful fallback completion
- Warning: Rate limit with Retry-After header
- Error: Translation failures with status codes and error details
- Critical: Both accounts failed

## Testing

```bash
cd ~/Olbrasoft/HandbookSearch
dotnet build  # ✅ Successful
dotnet test   # ✅ 17/17 tests passed
```

## Deployment Impact

**⚠️ Ready for production but NOT deployed yet** (as requested)

Once merged and deployed via `./deploy/deploy.sh`:
- CLI at `/opt/olbrasoft/handbook-search/cli/` will use fallback-enabled code
- GitHub Actions workflow in `engineering-handbook` will benefit from failover
- No configuration changes needed (fallback key already in GitHub Secrets)

## Next Steps

After merge:
1. Deploy using `./deploy/deploy.sh`
2. Complete production verification (engineering-handbook#48 Scenario 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)