### PR TITLE
Migrate HandbookSearch.AspNetCore.Api to SecureStore

### DIFF
--- a/src/HandbookSearch.AspNetCore.Api/Program.cs
+++ b/src/HandbookSearch.AspNetCore.Api/Program.cs
@@ -13,8 +13,8 @@ builder.Configuration.AddSecureStore();
 // Configuration
 builder.Services.Configure<OllamaOptions>(builder.Configuration.GetSection("Ollama"));
 
-// Database - build connection string from parts (password from SecureStore)
-var connectionString = BuildConnectionString(builder.Configuration.GetSection("Database"));
+// Database - build connection string from parts (password from SecureStore if configured)
+var connectionString = DatabaseConfigurationHelper.BuildConnectionString(builder.Configuration.GetSection("Database"));
 builder.Services.AddDbContext<HandbookSearchDbContext>(options =>
     options.UseNpgsql(connectionString, o => o.UseVector()));
 
@@ -115,25 +115,6 @@ app.MapGet("/api/search", async (
 .Produces<object>(500);
 
 app.Run();
-
-/// <summary>
-/// Builds a PostgreSQL connection string from configuration section.
-/// Password is expected from SecureStore (Database:Password key).
-/// </summary>
-static string BuildConnectionString(IConfigurationSection dbConfig)
-{
-    var host = dbConfig["Host"] ?? "localhost";
-    var database = dbConfig["Name"] ?? "handbook_search";
-    var username = dbConfig["Username"] ?? "postgres";
-    var password = dbConfig["Password"]; // From SecureStore
-
-    var connStr = $"Host={host};Database={database};Username={username}";
-    if (!string.IsNullOrEmpty(password))
-    {
-        connStr += $";Password={password}";
-    }
-    return connStr;
-}
 
 // Make Program class available to integration tests
 public partial class Program { }

--- a/src/HandbookSearch.AspNetCore.Api/appsettings.json
+++ b/src/HandbookSearch.AspNetCore.Api/appsettings.json
@@ -1,6 +1,8 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=handbook_search;Username=postgres"
+  "Database": {
+    "Host": "localhost",
+    "Name": "handbook_search",
+    "Username": "postgres"
   },
   "Ollama": {
     "BaseUrl": "http://localhost:11434",

--- a/src/HandbookSearch.Business/Configuration/DatabaseConfigurationHelper.cs
+++ b/src/HandbookSearch.Business/Configuration/DatabaseConfigurationHelper.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Olbrasoft.HandbookSearch.Business.Configuration;
+
+/// <summary>
+/// Helper class for building database connection strings from configuration.
+/// </summary>
+public static class DatabaseConfigurationHelper
+{
+    /// <summary>
+    /// Builds a PostgreSQL connection string from configuration section.
+    /// Password is loaded from SecureStore (Database:Password key) if available.
+    /// If not present, the connection string is built without a password (e.g. for local development).
+    /// </summary>
+    /// <param name="dbConfig">Configuration section containing Database settings (Host, Name, Username, Password).</param>
+    /// <returns>PostgreSQL connection string.</returns>
+    public static string BuildConnectionString(IConfigurationSection dbConfig)
+    {
+        ArgumentNullException.ThrowIfNull(dbConfig);
+
+        var host = dbConfig["Host"] ?? "localhost";
+        var database = dbConfig["Name"] ?? "handbook_search";
+        var username = dbConfig["Username"] ?? "postgres";
+        var password = dbConfig["Password"]; // From SecureStore if configured
+
+        var connStr = $"Host={host};Database={database};Username={username}";
+
+        if (!string.IsNullOrEmpty(password))
+        {
+            connStr += $";Password={password}";
+        }
+
+        return connStr;
+    }
+}

--- a/tests/HandbookSearch.Business.Tests/Configuration/DatabaseConfigurationHelperTests.cs
+++ b/tests/HandbookSearch.Business.Tests/Configuration/DatabaseConfigurationHelperTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Configuration;
+using Olbrasoft.HandbookSearch.Business.Configuration;
+
+namespace HandbookSearch.Business.Tests.Configuration;
+
+public class DatabaseConfigurationHelperTests
+{
+    [Fact]
+    public void BuildConnectionString_WithAllValues_ReturnsCompleteConnectionString()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Host"] = "myhost",
+                ["Database:Name"] = "mydb",
+                ["Database:Username"] = "myuser",
+                ["Database:Password"] = "mypassword"
+            })
+            .Build();
+
+        // Act
+        var result = DatabaseConfigurationHelper.BuildConnectionString(config.GetSection("Database"));
+
+        // Assert
+        Assert.Equal("Host=myhost;Database=mydb;Username=myuser;Password=mypassword", result);
+    }
+
+    [Fact]
+    public void BuildConnectionString_WithoutPassword_ReturnsConnectionStringWithoutPassword()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Host"] = "localhost",
+                ["Database:Name"] = "testdb",
+                ["Database:Username"] = "testuser"
+            })
+            .Build();
+
+        // Act
+        var result = DatabaseConfigurationHelper.BuildConnectionString(config.GetSection("Database"));
+
+        // Assert
+        Assert.Equal("Host=localhost;Database=testdb;Username=testuser", result);
+        Assert.DoesNotContain("Password", result);
+    }
+
+    [Fact]
+    public void BuildConnectionString_WithEmptyPassword_ReturnsConnectionStringWithoutPassword()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Host"] = "localhost",
+                ["Database:Name"] = "testdb",
+                ["Database:Username"] = "testuser",
+                ["Database:Password"] = ""
+            })
+            .Build();
+
+        // Act
+        var result = DatabaseConfigurationHelper.BuildConnectionString(config.GetSection("Database"));
+
+        // Assert
+        Assert.Equal("Host=localhost;Database=testdb;Username=testuser", result);
+        Assert.DoesNotContain("Password", result);
+    }
+
+    [Fact]
+    public void BuildConnectionString_WithDefaults_ReturnsDefaultValues()
+    {
+        // Arrange - empty configuration
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        // Act
+        var result = DatabaseConfigurationHelper.BuildConnectionString(config.GetSection("Database"));
+
+        // Assert
+        Assert.Equal("Host=localhost;Database=handbook_search;Username=postgres", result);
+    }
+
+    [Fact]
+    public void BuildConnectionString_NullDbConfig_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IConfigurationSection? dbConfig = null;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => DatabaseConfigurationHelper.BuildConnectionString(dbConfig!));
+    }
+
+    [Fact]
+    public void BuildConnectionString_PartialConfig_UsesDefaults()
+    {
+        // Arrange - only host specified
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Host"] = "custom-host"
+            })
+            .Build();
+
+        // Act
+        var result = DatabaseConfigurationHelper.BuildConnectionString(config.GetSection("Database"));
+
+        // Assert
+        Assert.Contains("Host=custom-host", result);
+        Assert.Contains("Database=handbook_search", result);
+        Assert.Contains("Username=postgres", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add SecureStore configuration for encrypted secrets to API
- Replace `ConnectionStrings` with `Database` section
- Build connection string from parts (password from SecureStore)

## Changes
- `src/HandbookSearch.AspNetCore.Api/Program.cs` - Add AddSecureStore(), BuildConnectionString helper
- `src/HandbookSearch.AspNetCore.Api/appsettings.json` - Use Database section instead of ConnectionStrings

## Configuration
Non-secret config in appsettings.json:
```json
{
  "Database": {
    "Host": "localhost",
    "Name": "handbook_search",
    "Username": "postgres"
  }
}
```

Password from SecureStore: `Database:Password`

## Test plan
- [x] All tests pass (32 tests)
- [x] Build succeeds
- [ ] API starts and responds to /api/search (manual test)

**Depends on:** #42 (PR for #36)

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)