### PR TITLE
Migrate HandbookSearch.Cli to SecureStore

### DIFF
--- a/src/HandbookSearch.Cli/appsettings.json
+++ b/src/HandbookSearch.Cli/appsettings.json
@@ -1,6 +1,8 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=handbook_search;Username=postgres"
+  "Database": {
+    "Host": "localhost",
+    "Name": "handbook_search",
+    "Username": "postgres"
   },
   "Ollama": {
     "BaseUrl": "http://localhost:11434",
@@ -8,7 +10,6 @@
     "Dimensions": 1024
   },
   "AzureTranslator": {
-    "ApiKey": "from-environment-variable-AZURE_TRANSLATOR_API_KEY",
     "Region": "westeurope",
     "Endpoint": "https://api.cognitive.microsofttranslator.com"
   },


### PR DESCRIPTION
## Summary
- Add SecureStore configuration for encrypted secrets to CLI
- Replace `ConnectionStrings` with `Database` section
- Remove hardcoded ApiKey from AzureTranslator section
- API keys and password loaded from SecureStore

## Changes
- `src/HandbookSearch.Cli/Program.cs` - Add AddSecureStore(), BuildConnectionString helper
- `src/HandbookSearch.Cli/appsettings.json` - Use Database section, remove hardcoded ApiKey

## SecureStore Keys
- `Database:Password` - PostgreSQL password
- `AzureTranslator:ApiKey` - Azure Translator API key
- `AzureTranslator:FallbackApiKey` - Fallback API key (optional)

## Test plan
- [x] All tests pass (32 tests)
- [x] Build succeeds
- [ ] CLI commands work (manual test)

**Depends on:** #43 (PR for #37)

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)